### PR TITLE
Adding new recipes for `AbstractVector{TriPseudocolor}`

### DIFF
--- a/examples/dolphin.jl
+++ b/examples/dolphin.jl
@@ -6,7 +6,14 @@ x,y = eachcol(readdlm(joinpath(@__DIR__,"dolphin.xy")))
 t = readdlm(joinpath(@__DIR__,"dolphin.t"),Int)' .+ 1
 z = f.(x,y)
 
+# plots a dolphin
 plot(aspect_ratio=:equal,size=(800,720))
 tripcolor!(x,y,z,t,color=:magma)
 trimesh!(x,y,t,fillalpha=0.0,linecolor=:white)
 savefig("dolphin.png")
+
+# plots two dolphins using a vector of TriPseudocolor instances
+using TriplotRecipes: TriPseudocolor
+plist = [TriPseudocolor(x,y,z,t), TriPseudocolor(x .+ 0.5, y, z, t)]
+plot(plist, color=:magma)
+savefig("two_dolphins.png")

--- a/src/TriplotRecipes.jl
+++ b/src/TriplotRecipes.jl
@@ -46,7 +46,7 @@ struct TriPseudocolor{X,Y,Z,T} x::X; y::Y; z::Z; t::T; end
 end
 
 # plots a vector of TriPseudocolor instances by merging them.
-@recipe function f(plist::Vector{<:TriPseudocolor}; 
+@recipe function f(plist::AbstractVector{<:TriPseudocolor}; 
                    px=512, py=512, ncolors=256) 
                
     x = eltype(plist[1].x)[]

--- a/src/TriplotRecipes.jl
+++ b/src/TriplotRecipes.jl
@@ -45,6 +45,42 @@ struct TriPseudocolor{X,Y,Z,T} x::X; y::Y; z::Z; t::T; end
     x,y,z'
 end
 
+# plots a vector of TriPseudocolor instances by merging them.
+@recipe function f(plist::Vector{<:TriPseudocolor}; 
+                   px=512, py=512, ncolors=256) 
+               
+    x = eltype(plist[1].x)[]
+    y = eltype(plist[1].y)[]
+
+    # TriplotBase.dgtripcolor requires `z` and `t` be the same size
+    num_triangles_total = mapreduce(x->size(x.t, 2), +, plist)
+    z = Matrix{eltype(plist[1].z)}(undef, 3, num_triangles_total)
+    t = Matrix{eltype(plist[1].t)}(undef, 3, num_triangles_total) 
+
+    vertex_offset = zero(eltype(t))
+    triangle_offset = zero(eltype(t))
+    for p in plist
+        @assert length(p.x) == length(p.y) == length(p.z)
+        append!(x, p.x)
+        append!(y, p.y)
+        num_vertices = length(p.x)
+        num_triangles = size(p.t, 2)
+        columns = (1:num_triangles) .+ triangle_offset
+        @. z[:, columns] = p.z[p.t]
+        @. t[:, columns] = p.t + vertex_offset
+        vertex_offset += num_vertices
+        triangle_offset += num_triangles
+    end
+
+    cmap = range(extrema(z)..., length=ncolors)
+    xx = range(extrema(x)..., length=px)
+    yy = range(extrema(y)..., length=py)
+    zz = TriplotBase.dgtripcolor(x, y, z, t, cmap; bg=NaN, px=px, py=py)
+
+    seriestype := :heatmap
+    xx, yy, zz'
+end
+
 tripcolor(x,y,z,t;kw...) = RecipesBase.plot(TriPseudocolor(x,y,z,t);kw...)
 tripcolor!(x,y,z,t;kw...) = RecipesBase.plot!(TriPseudocolor(x,y,z,t);kw...)
 


### PR DESCRIPTION
Adding a recipe for plotting a vector of `TriPseudocolor` objects by converting it into `TriplotBase.dgtripcolor` format.

I tried using a Type recipe to reuse the `DGTriPseudocolor` recipe, but had issues with the strictness of the type specification (it had issues with `Vector{<:TriPseudocolor}` and needed complete type specification `Vector{TriPseudocolor{TX, TY, TZ, TT}}`, which wouldn't allow `TriPseudocolor` objects with different field types to be combined together). 